### PR TITLE
Set the default dimension for creating waypoint to be the player's current dimension

### DIFF
--- a/common/src/main/java/xyz/wagyourtail/minimap/client/gui/screen/WaypointEditScreen.java
+++ b/common/src/main/java/xyz/wagyourtail/minimap/client/gui/screen/WaypointEditScreen.java
@@ -50,12 +50,7 @@ public class WaypointEditScreen extends Screen {
     public static WaypointEditScreen createNewFromPos(Screen parent, BlockPos pos) {
         Minecraft mc = Minecraft.getInstance();
         int color = Color.HSBtoRGB(random.nextFloat(), 1f, 1f);
-        String[] dims;
-        if (mc.level.dimension().equals(Level.OVERWORLD) || mc.level.dimension().equals(Level.NETHER)) {
-            dims = new String[] {"minecraft/overworld", "minecraft/the_nether"};
-        } else {
-            dims = new String[] {MinimapApi.getInstance().getMapServer().getLevelFor(mc.level).level_slug()};
-        }
+        String[] dims = new String[] {MinimapApi.getInstance().getMapServer().getLevelFor(mc.level).level_slug()};
 
         return new WaypointEditScreen(parent, new Waypoint(
             mc.level.dimensionType().coordinateScale(),


### PR DESCRIPTION
When the user goes to create a waypoint, instead of creating it for the overworld and nether by default regardless of the dimension the player is in (leaving unneeded waypoints being displayed from different dimensions), we only set it to whatever current dimension the player is in by default.